### PR TITLE
Bug fix for missing entry in 'allPointers' when freeing cuda block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss z</maven.build.timestamp.format>
 		<enableGPU>false</enableGPU>
 		<jcuda.scope>provided</jcuda.scope>
-		<jcuda.version>0.9.0</jcuda.version>
+		<jcuda.version>0.9.0d</jcuda.version>
 		<!-- OS-specific JVM arguments for running integration tests -->
 		<integrationTestExtraJVMArgs />
 	</properties>

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/CSRPointer.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/CSRPointer.java
@@ -523,12 +523,14 @@ public class CSRPointer {
 	 * @throws DMLRuntimeException ?
 	 */
 	public void deallocate(boolean eager) throws DMLRuntimeException {
-		if(val != null && val != GPUMemoryManager.EMPTY_POINTER)
-			getGPUContext().cudaFreeHelper(null, val, eager);
-		if(rowPtr != null && rowPtr != GPUMemoryManager.EMPTY_POINTER)
-			getGPUContext().cudaFreeHelper(null, rowPtr, eager);
-		if(colInd != null && colInd != GPUMemoryManager.EMPTY_POINTER)
-			getGPUContext().cudaFreeHelper(null, colInd, eager);
+		if (nnz > 0) {
+			if (val != null)
+				getGPUContext().cudaFreeHelper(null, val, eager);
+			if (rowPtr != null)
+				getGPUContext().cudaFreeHelper(null, rowPtr, eager);
+			if (colInd != null)
+				getGPUContext().cudaFreeHelper(null, colInd, eager);
+		}
 		val = null;
 		rowPtr = null;
 		colInd = null;

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUMemoryManager.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUMemoryManager.java
@@ -366,30 +366,27 @@ public class GPUMemoryManager {
 			sb.append("\n");
 		}
 	}
-	
-	public static final Pointer EMPTY_POINTER = new Pointer();
-	
+
 	/**
 	 * Note: This method should not be called from an iterator as it removes entries from allocatedGPUPointers and rmvarGPUPointers
 	 * 
 	 * @param toFree pointer to call cudaFree method on
 	 */
 	void guardedCudaFree(Pointer toFree) {
-		if (toFree != EMPTY_POINTER) {
-			if(allPointers.containsKey(toFree)) {
-				long size = allPointers.get(toFree).getSizeInBytes();
-				if(LOG.isTraceEnabled()) {
-					LOG.trace("Free-ing up the pointer of size " +  byteCountToDisplaySize(size));
-				}
-				allPointers.remove(toFree);
-				lazyCudaFreeMemoryManager.removeIfPresent(size, toFree);
-				cudaFree(toFree);
-				// JCuda.cudaDeviceSynchronize(); // Force a device synchronize after free-ing the pointer for debugging
+		if(allPointers.containsKey(toFree)) {
+			long size = allPointers.get(toFree).getSizeInBytes();
+			if(LOG.isTraceEnabled()) {
+				LOG.trace("Free-ing up the pointer of size " +  byteCountToDisplaySize(size));
 			}
-			else {
-				throw new RuntimeException("Attempting to free an unaccounted pointer:" + toFree);
-			}
+			allPointers.remove(toFree);
+			lazyCudaFreeMemoryManager.removeIfPresent(size, toFree);
+			cudaFree(toFree);
+			// JCuda.cudaDeviceSynchronize(); // Force a device synchronize after free-ing the pointer for debugging
 		}
+		else {
+			throw new RuntimeException("Attempting to free an unaccounted pointer:" + toFree);
+		}
+
 	}
 	
 	/**
@@ -401,9 +398,6 @@ public class GPUMemoryManager {
 	 * @throws DMLRuntimeException if error
 	 */
 	public void free(String opcode, Pointer toFree, boolean eager) throws DMLRuntimeException {
-		if (toFree == EMPTY_POINTER) { // trying to free a null pointer
-			return;
-		}
 		if(LOG.isTraceEnabled())
 			LOG.trace("Free-ing the pointer with eager=" + eager);
 		if (eager) {
@@ -562,12 +556,12 @@ public class GPUMemoryManager {
 			totalSizePotentiallyLeakyPointers += size;
 		}
 		StringBuilder ret = new StringBuilder();
-		if(DMLScript.PRINT_GPU_MEMORY_INFO) {
-			if(potentiallyLeakyPointers.size() > 0) {
-				ret.append("Non-matrix pointers were allocated by:\n");
-				printPointers(potentiallyLeakyPointers, ret);
-			}
-		}
+		//if(DMLScript.PRINT_GPU_MEMORY_INFO) {
+		//	if(potentiallyLeakyPointers.size() > 0) {
+		//		ret.append("Non-matrix pointers were allocated by:\n");
+		//		printPointers(potentiallyLeakyPointers, ret);
+		//	}
+		//}
 		ret.append("\n====================================================\n");
 		ret.append(String.format("%-35s%-15s%-15s%-15s\n", "", 
 				"Num Objects", "Num Pointers", "Size"));


### PR DESCRIPTION
The bug was that to check whether a Pointer was empty, it was being
compared with an '==' to a 'new Pointer()'. The '==' only did a memory
address comparison and not field-wise comparison as was expected.
The fix was to not try and free an empty CSR block by checking the nnz.